### PR TITLE
Fix typos and improve wording in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1090,7 +1090,7 @@ posix_spawn();
 
 ### Metamorph
 
-🪄This is the most magical Actor operation. It replaces running Actor’s Docker image with another Actor,
+This is the most magical Actor operation. It replaces running Actor’s Docker image with another Actor,
 similarly to UNIX `exec` command.
 It is used for building new Actors on top of existing ones.
 You simply define input schema and write README for a specific use case,
@@ -1661,7 +1661,7 @@ The SDK is currently available for Node.js, Python, and CLI.
 
 ### Local development
 
-Actor programming model is language agnostic, but the framework has native support for detection of JavaScript and Python languages. 
+The Actor programming model is language agnostic, but the framework has native support for detection of JavaScript and Python languages. 
 
 Tip: [Apify CLI](https://docs.apify.com/cli/docs/next/reference#apify-create-actorname) provides [convenient templates](https://apify.com/templates) to bootstrap an Actor in Python, JavaScript, and TypeScript.
 
@@ -1701,7 +1701,7 @@ CMD actor push-data $(actor get-input)
 EOF
 ```
 
-#### Run to test the Actor localy
+#### Run to test the Actor locally
 ```
 $ echo '{"bar": "foo"}' | actor run -o -s
 [{

--- a/pages/ACTOR_FILE.md
+++ b/pages/ACTOR_FILE.md
@@ -24,7 +24,7 @@ The file has the following structure:
   // to get started and be kept alive by the system to handle incoming HTTP REST requests by the Actor's web server.
   "usesStandbyMode": true,
  
-  // A meta object enabling impelemtations to pass arbitrary additional properties
+  // A meta object enabling implementations to pass arbitrary additional properties
   "meta": {
     "something": "bla bla"
   },
@@ -33,7 +33,7 @@ The file has the following structure:
   "minMemoryMbytes": 128,
   "maxMemoryMbytes": 4096,
   
-  // Links to other Actor defintion files
+  // Links to other Actor definition files
   "dockerfile": "./Dockerfile", // If omitted, the system looks for "./Dockerfile" and "../Dockerfile"
   "readme": "./README.md", // If omitted, the system looks for "./ACTOR.md" and "../README.md"
   "changelog": "../../../shared/CHANGELOG.md",

--- a/pages/DATASET_SCHEMA.md
+++ b/pages/DATASET_SCHEMA.md
@@ -44,7 +44,7 @@ Uncaught Error: Dataset schema is not compatible with the provided schema
 ```jsonc
 {
     "actorDatasetSchemaVersion": 1,
-    "title": "Eshop products",
+    "title": "E-shop products",
     "description": "Dataset containing the whole product catalog including prices and stock availability.",
 
     // A JSON schema object describing the dataset fields, with our extensions: the "title", "description", and "example" properties.
@@ -98,7 +98,7 @@ Uncaught Error: Dataset schema is not compatible with the provided schema
                     },                           
                     "imageUrl": {
                         "label": "Image",
-                        "format": "image" // optional, in this case the format is overriden to show "image" instead of image link "text". "image" format only works with .jpeg, .png or other image format urls.
+                        "format": "image" // optional, in this case the format is overridden to show "image" instead of image link "text". "image" format only works with .jpeg, .png or other image format urls.
                     },
                     "stockInfo.availability": {
                         "label": "Availability"

--- a/pages/IDEAS.md
+++ b/pages/IDEAS.md
@@ -7,7 +7,7 @@ Here you can find random ideas and notes, in no particular order, relevance, or 
 
 
 - Add ideas for the permission system
-  - Note from Marek regarding permissision:
+  - Note from Marek regarding permission:
   - Just a note on this, I was thinking about how this could be done systematically, so dropping the notes here:
   - By default, the Actor should have following permissions that the user would accept when running the Actor for the first time:
       - Write to all the default + named storages linked in the output schema

--- a/pages/OUTPUT_SCHEMA.md
+++ b/pages/OUTPUT_SCHEMA.md
@@ -107,7 +107,7 @@ there's no point to include storage schema here again, as it's done elsewhere.
 - Same as we show Output in UI, we need to autogenerate the OUTPUT in API e.g. JSON format.
   There would be properties like in the output_schema.json file, with e.g. URL to dataset,
   log file, kv-store, live view etc. So it would be an auto-generated field "output"
-  that we can add to JSON returned by the Run API enpoints
+  that we can add to JSON returned by the Run API endpoints
   (e.g. https://docs.apify.com/api/v2#/reference/actor-tasks/run-collection/run-task)
   - Also see: https://github.com/apify/actor-specs/pull/5#discussion_r775641112
   - `output` will be a property of run object generated from Output schema


### PR DESCRIPTION
Various documentation files have been updated to fix typos and improve clarity:

- Fix typo "localy" to "locally" in README
- Correct "impelemtations" to "implementations" in ACTOR_FILE
- Update "Eshop" to "E-shop" in DATASET_SCHEMA
- Fix "permissision" to "permission" in IDEAS
- Correct "enpoints" to "endpoints" in OUTPUT_SCHEMA
- Add missing articles and improve grammar in several places