### PR TITLE
Vale linting

### DIFF
--- a/.github/styles/config/vocabularies/Whitepaper/accept.txt
+++ b/.github/styles/config/vocabularies/Whitepaper/accept.txt
@@ -1,0 +1,24 @@
+# General
+Whitepaper
+
+# Companies
+Apify
+Zapier
+
+# Apify-related
+(?i)actor(izing|ization)
+
+# Technologies
+Dockerfile
+SDKs
+automations
+env
+microapps
+msg
+serverless
+storages
+
+# People
+Franta
+Marek
+Ondra

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+.DS_Store
 .idea
 node_modules
 package-lock.json
+
+# Vale
+.github/styles/*
+!.github/styles/config/
+
+.github/styles/config/*
+!.github/styles/config/vocabularies/
+
+.github/styles/config/vocabularies/*
+!.github/styles/config/vocabularies/Whitepaper

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,20 @@
+StylesPath = .github/styles
+MinAlertLevel = warning
+IgnoredScopes = code, tt, table, tr, td
+
+Vocab = Whitepaper
+
+Packages = write-good, Microsoft, Readability
+
+[formats]
+mdx = md
+
+[*.md]
+BasedOnStyles = Vale, write-good, Microsoft, Readability
+# Ignore URLs, HTML/XML tags, lines with =, Markdown links, emails, curly braces, inline code
+TokenIgnores = (<\/?[A-Z][^>]*>), ([^\n]+=[^\n]*), (\[[^\]]+\]\([^\)]+\)), ([^\n]+@[^\n]+\.[^\n]), ({[^}]*}), `[^`]+`
+# Ignore HTML comments and Markdown code blocks
+BlockIgnores = (?s) (<!--.*?-->)|(```.*?```)
+Vale.Spelling = YES
+
+# Disabling rules (NO)


### PR DESCRIPTION
This PR adds the [Vale](https://vale.sh) linting – so far only via Vale [CLI](https://vale.sh/docs/cli) (or extensions: [VSCode](https://github.com/chrischinchilla/vale-vscode), [JetBrains](https://plugins.jetbrains.com/plugin/19613-vale-cli/docs)).

The goal is to integrate Vale as a GitHub Action.

Please try Vale and see how it can be helpful for the content here. I already added some words to the dictionary (in `.github/styles/config/vocabularies/Whitepaper/accept.txt`), be free to add more. There are already some helpful results that we may fix quickly:

## README.md

```
 1:1      warning  Try to keep the SMOG grade      Readability.SMOG              
                   (10.36) below 10.                                             
 1:1      warning  Try to keep the Flesch reading  Readability.FleschReadingEase 
                   ease score (64.91) above 70.                                  
 3:8      error    Use 'Whitepaper' instead of     Vale.Terms                    
                   'whitepaper'.                                                 
 6:25     warning  Prefer 'cloud' over 'the        Microsoft.Terms               
                   cloud'.                                                       
 79:6     error    Use 'Whitepaper' instead of     Vale.Terms                    
                   'whitepaper'.                                                 
 90:13    warning  Remove 'easily' if it's not     Microsoft.Adverbs             
                   important to the meaning of                                   
                   the statement.                                                
 96:1     warning  Try to avoid using              Microsoft.We                  
                   first-person plural like 'we'.                                
 96:22    error    Use 'Whitepaper' instead of     Vale.Terms                    
                   'whitepaper'.                                                 
 98:1     warning  Try to avoid using              Microsoft.We                  
                   first-person plural like 'We'.                                
 99:39    warning  Remove 'effectively' if it's    Microsoft.Adverbs             
                   not important to the meaning                                  
                   of the statement.                                             
 103:18   error    Use 'Whitepaper' instead of     Vale.Terms                    
                   'whitepaper'.                                                 
 105:64   warning  'is provided' may be passive    write-good.Passive            
                   voice. Use active voice if you                                
                   can.                                                          
 110:42   warning  'implement' is too wordy.       write-good.TooWordy           
 111:19   error    Use 'Whitepaper' instead of     Vale.Terms                    
                   'whitepaper'.                                                 
 115:44   warning  Prefer 'cloud' over 'the        Microsoft.Terms               
                   cloud'.                                                       
 120:36   warning  'be restarted' may be passive   write-good.Passive            
                   voice. Use active voice if you                                
                   can.                                                          
 137:79   warning  Remove 'easily' if it's not     Microsoft.Adverbs             
                   important to the meaning of                                   
                   the statement.                                                
 140:12   warning  Remove 'easily' if it's not     Microsoft.Adverbs             
                   important to the meaning of                                   
                   the statement.                                                
 148:12   warning  'be published' may be passive   write-good.Passive            
                   voice. Use active voice if you                                
                   can.                                                          
 151:33   warning  'in order to' is too wordy.     write-good.TooWordy           
 167:54   error    Use 'they're' instead of 'they  Microsoft.Contractions        
                   are'.                                                         
 173:12   warning  'is passed' may be passive      write-good.Passive            
                   voice. Use active voice if you                                
                   can.                                                          
 256:61   warning  'be used' may be passive        write-good.Passive            
                   voice. Use active voice if you                                
                   can.                                                          
 280:115  error    Use 'for example' instead of    Microsoft.Foreign             
                   'e.g.'.                                                       
 435:49   warning  'various' is a weasel word!     write-good.Weasel             
 448:24   warning  Try to avoid using              Microsoft.We                  
                   first-person plural like                                      
                   'our'.                                                        
 491:71   warning  'implement' is too wordy.       write-good.TooWordy           
 1727:31  warning  'be hosted' may be passive      write-good.Passive            
                   voice. Use active voice if you                                
                   can.                                                          
 1730:30  error    Use 'Whitepaper' instead of     Vale.Terms                    
                   'whitepaper'.                                                 
 1739:41  warning  'usually' is a weasel word!     write-good.Weasel             
 1760:15  warning  Prefer 'cloud' over 'the        Microsoft.Terms               
                   cloud'.                                                       
 1760:72  warning  Remove 'easily' if it's not     Microsoft.Adverbs             
                   important to the meaning of                                   
                   the statement.                                                
 1765:15  warning  'is developed' may be passive   write-good.Passive            
                   voice. Use active voice if you                                
                   can.                                                          
 1777:30  warning  'usually' is a weasel word!     write-good.Weasel             
 1806:18  error    Use 'Whitepaper' instead of     Vale.Terms                    
                   'whitepaper'.                                                 
 1808:29  warning  'however' is too wordy.         write-good.TooWordy           
 1810:3   warning  'Finalize' is too wordy.        write-good.TooWordy           
 1811:3   warning  'Clearly' is a weasel word!     write-good.Weasel             
 1811:20  error    Use 'what's' instead of 'what   Microsoft.Contractions        
                   is'.                                                          
 1811:57  error    Use 'what's' instead of 'what   Microsoft.Contractions        
                   is'.                                                          
 1817:26  error    Punctuation should be inside    Microsoft.Quotes              
                   the quotes.                                                   
 1817:27  error    Don't use 'backend'. See the    Microsoft.Avoid               
                   A-Z word list for details.                                    

✖ 13 errors, 29 warnings and 0 suggestions in 1 file.
```

The question is if we need `Readability.FleschReadingEase` and `Readability.SMOG`. Maybe that's too restricting, but I will leave the decision to you :)

Thanks, @TC-MO, for starting this and helping with the integration and config file.

/c @davidjohnbarton, @OlikEten, @jancurn @netmilk 