### PR TITLE
Content Sync: Fixing the branch name

### DIFF
--- a/.github/workflows/sync-to-astro.yml
+++ b/.github/workflows/sync-to-astro.yml
@@ -4,8 +4,7 @@ name: Sync Whitepaper to Astro (PR flow)
 on:
   push:
     branches:
-      - main
-      - feat/gh-57-content-sync
+      - master
     paths:
       - '*.md'
       - 'pages/**/*.md'


### PR DESCRIPTION
The sync workflow has the wrong branch name: `main`. It should be `master`, as that's what the primary branch is called here.

Fixes #66 